### PR TITLE
Add tag options to remove code inside single line comments.

### DIFF
--- a/tasks/strip_code.js
+++ b/tasks/strip_code.js
@@ -17,16 +17,30 @@ module.exports = function(grunt) {
 
     var options = this.options({
           start_comment: "test-code",
-          end_comment: "end-test-code"
-        })
-      , pattern = options.pattern || new RegExp(
-            "[\\t ]*\\/\\* ?"
-          + options.start_comment
-          + " ?\\*\\/[\\s\\S]*?\\/\\* ?"
-          + options.end_comment
-          + " ?\\*\\/[\\t ]*\\n?"
-          , "g"
-        );
+          end_comment: "end-test-code",
+          tag:"debug"
+        });
+
+    var pattern = [];
+
+    pattern[0] = options.pattern || new RegExp(
+        "[\\t ]*\\/\\* ?"
+        + options.start_comment
+        + " ?\\*\\/[\\s\\S]*?\\/\\* ?"
+        + options.end_comment
+        + " ?\\*\\/[\\t ]*\\n?"
+        , "g"
+      );
+
+    pattern[1] = new RegExp(
+        "[\\s]+?\\/(\\/|\\s)+?<"
+        + options.tag
+        + ">((.|\\s)+?)\\/(\\/|\\s)+?<\/"
+        + options.tag
+        + ">"
+        , "g"
+      );
+
     // Iterate over all specified file groups.
     this.files.forEach(function(f) {
       // Concat specified files.
@@ -36,10 +50,19 @@ module.exports = function(grunt) {
           grunt.log.warn('Source file "' + filepath + '" not found.');
           return;
         }
-        var contents = grunt.file.read(filepath)
-          , replacement = contents.replace(pattern, "");
+
+        var contents = grunt.file.read(filepath);
+        var replacement = "";
+
+        if (options.pattern) {
+          replacement = contents.replace(pattern[0], "");
+        } else {
+          replacement = contents.replace (pattern[0], "");
+          replacement = replacement.replace (pattern[1], "");
+        }
+
         // if replacement is different than contents, save file and print a success message.
-        if (contents != replacement) {
+        if (contents !== replacement) {
           if (f.dest) {
             grunt.file.write(f.dest, replacement);
             grunt.log.writeln("Stripped code from " + filepath + " and saved to " + f.dest);

--- a/test/expected/default_options.js
+++ b/test/expected/default_options.js
@@ -3,7 +3,12 @@
   var foo;
 
 
+  var test;
+
   return {
     bar: "bar"
+,   html    :"	<debug> "
+            +"	test"
+            +"	</debug>"
   };
 }());

--- a/test/fixtures/default_options.js
+++ b/test/fixtures/default_options.js
@@ -6,8 +6,20 @@
   function bar() { }
   /* end-test-code */
 
+  var test;
+
+  // <debug>
+  function test() {}
+  // </debug>
+
   return {
     bar: "bar"
     /* test-code */ , fizz: "buzz" /* end-test-code */
+,   html    :"	<debug> "
+            +"	test"
+            +"	</debug>"
+	//<debug>
+,	debug	:"debug"
+	//</debug>
   };
 }());


### PR DESCRIPTION
Add feature to remove line of codes inside single line comment. E.g:

    var a
    // <debug>
    var debug;
    // </debug>
    var b;

with,

    options: {
      tag: "debug" // default
    }

will result in,

    var a;
    var b;