### PR TITLE
Need to specify targets or you get an EISDIR. Grunt tries to run strip_code:src which is not correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ grunt.initConfig({
       start_comment: 'start-test-block',
       end_comment: 'end-test-block',
     },
-    src: 'dist/*.js'
+    your_target: {
+      src: 'dist/*.js'
+    }
   },
 })
 ```
@@ -117,7 +119,9 @@ grunt.initConfig({
     options: {
       pattern: /log\(\)/g
     },
-    src: 'dist/*.js'
+    your_target: {
+      src: 'dist/*.js'
+    }
   },
 })
 ```


### PR DESCRIPTION
Just a simple README update for those of us who sometimes blindly copy/paste from the internet.