### PR TITLE
Allow custom end-of-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ Default value: `false`
 
 Turns on check that makes sure if you blocks does not intersect between each other.
 
+#### options.eol
+Type: `String`
+Choices: `'lf'`, `'cr'`, `'crlf'`
+Default value: `''`
+
+Unless one of the choices is explicitly specified, end-of-line defaults to the operating system specific character(s).
+
 ### Usage Examples
 
 The following source code exposes the `bar` function to the public API for testing, but the `bar` function should not be accessible in the released library. grunt-strip-code (with the default options) will remove the comment blocks from the example below keeping the `bar` function private in production:

--- a/tasks/strip_code.js
+++ b/tasks/strip_code.js
@@ -60,8 +60,33 @@ module.exports = function (grunt) {
             //Legacy
             start_comment: false,
             end_comment: false,
-            pattern: false
+            pattern: false,
+            eol: ''
         });
+
+
+        //
+        // Allow custom end-of-line, if specified.
+        //
+        var endOfLine;
+
+        switch(options.eol) {
+          case 'cr':
+            endOfLine = '\r';
+            break;
+
+          case 'lf':
+            endOfLine = '\n';
+            break;
+
+          case 'crlf':
+            endOfLine = '\r\n';
+            break;
+
+          default:
+            endOfLine = grunt.util.linefeed;
+            break;
+        }
 
         /**
          * Takes in dynamic parameters and expects first param to be a key for a string,
@@ -174,7 +199,7 @@ module.exports = function (grunt) {
                 '[\\s\\S]*?',
                 escapeStringRegexp(raw_blocks.end_block),
                 '[\\t ]*',
-                escapeStringRegexp(grunt.util.linefeed) + '?'
+                escapeStringRegexp(endOfLine) + '?'
             ];
 
             return {
@@ -370,7 +395,7 @@ module.exports = function (grunt) {
                 /**
                  * Process every line of the current file with main 'check' function
                  */
-                contents.split(grunt.util.linefeed).forEach(checkLine);
+                contents.split(endOfLine).forEach(checkLine);
 
                 /**
                  * Strip block match from file


### PR DESCRIPTION
Working in mixed-mode repositories, the code may
not necessarily follow os defined eol specified
by grunt.util.linefeed.

Allow custom 'eol' to be specified by the user.

Default behavior to use grunt.util.linefeed is
retained.

Signed-off-by: Sanjeev Premi <spremi@ymail.com>